### PR TITLE
TerminalExpressionEvaluationContext extends EnvironmentContext

### DIFF
--- a/src/main/java/walkingkooka/terminal/expression/function/FakeTerminalExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/terminal/expression/function/FakeTerminalExpressionEvaluationContext.java
@@ -17,10 +17,13 @@
 
 package walkingkooka.terminal.expression.function;
 
+import walkingkooka.environment.EnvironmentValueName;
+import walkingkooka.net.email.EmailAddress;
 import walkingkooka.text.LineEnding;
 import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
 import java.util.Optional;
+import java.util.Set;
 
 public class FakeTerminalExpressionEvaluationContext extends FakeExpressionEvaluationContext implements TerminalExpressionEvaluationContext {
 
@@ -55,6 +58,29 @@ public class FakeTerminalExpressionEvaluationContext extends FakeExpressionEvalu
 
     @Override
     public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    // EnvironmentContext...............................................................................................
+
+    @Override
+    public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<EnvironmentValueName<?>> environmentValueNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> TerminalExpressionEvaluationContext setEnvironmentValue(final EnvironmentValueName<T> name,
+                                                                       final T value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<EmailAddress> user() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContext.java
@@ -17,11 +17,18 @@
 
 package walkingkooka.terminal.expression.function;
 
+import walkingkooka.environment.EnvironmentContext;
+import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.terminal.TerminalContext;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
 /**
  * A {@link ExpressionEvaluationContext} with added {@link TerminalContext} support.
  */
-public interface TerminalExpressionEvaluationContext extends ExpressionEvaluationContext, TerminalContext {
+public interface TerminalExpressionEvaluationContext extends ExpressionEvaluationContext, TerminalContext,
+    EnvironmentContext {
+
+    @Override
+    <T> TerminalExpressionEvaluationContext setEnvironmentValue(final EnvironmentValueName<T> name,
+                                                                final T value);
 }

--- a/src/main/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContextTesting.java
@@ -17,11 +17,13 @@
 
 package walkingkooka.terminal.expression.function;
 
+import walkingkooka.environment.EnvironmentContextTesting2;
 import walkingkooka.terminal.TerminalContextTesting;
 import walkingkooka.tree.expression.ExpressionEvaluationContextTesting;
 
 public interface TerminalExpressionEvaluationContextTesting<C extends TerminalExpressionEvaluationContext> extends ExpressionEvaluationContextTesting<C>,
-    TerminalContextTesting<C> {
+    TerminalContextTesting<C>,
+    EnvironmentContextTesting2<C> {
 
     @Override//
     default String typeNamePrefix() {

--- a/src/test/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContextTestingTest.java
+++ b/src/test/java/walkingkooka/terminal/expression/function/TerminalExpressionEvaluationContextTestingTest.java
@@ -21,10 +21,14 @@ import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
+import walkingkooka.environment.EnvironmentContext;
+import walkingkooka.environment.EnvironmentContextDelegator;
 import walkingkooka.environment.EnvironmentContexts;
+import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.net.email.EmailAddress;
 import walkingkooka.terminal.TerminalContext;
 import walkingkooka.terminal.TerminalContexts;
 import walkingkooka.terminal.expression.TerminalContextDelegator;
@@ -39,6 +43,7 @@ import walkingkooka.tree.expression.convert.ExpressionNumberConverterContexts;
 
 import java.math.MathContext;
 import java.text.DateFormatSymbols;
+import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -147,7 +152,8 @@ public class TerminalExpressionEvaluationContextTestingTest implements TerminalE
 
     static class TestTerminalExpressionEvaluationContext implements TerminalExpressionEvaluationContext,
         ExpressionEvaluationContextDelegator,
-        TerminalContextDelegator {
+        TerminalContextDelegator,
+        EnvironmentContextDelegator {
 
         @Override
         public ExpressionEvaluationContext enterScope(final Function<ExpressionReference, Optional<Optional<Object>>> scoped) {
@@ -166,6 +172,32 @@ public class TerminalExpressionEvaluationContextTestingTest implements TerminalE
         @Override
         public TerminalContext terminalContext() {
             return TerminalContexts.system();
+        }
+
+        // EnvironmentContext...........................................................................................
+
+        @Override
+        public <T> TestTerminalExpressionEvaluationContext setEnvironmentValue(final EnvironmentValueName<T> name,
+                                                                               final T value) {
+            Objects.requireNonNull(name, "name");
+            Objects.requireNonNull(value, "value");
+
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LocalDateTime now() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnvironmentContext environmentContext() {
+            return EnvironmentContexts.empty(
+                LocalDateTime::now,
+                Optional.of(
+                    EmailAddress.parse("user@example.com")
+                )
+            );
         }
 
         // ExpressionEvaluationContextDelegator.........................................................................


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-terminal/issues/19
- TerminalExpressionEvaluationContext should extend EnvironmentContext